### PR TITLE
docs(agenda): reference developers-conferences-agenda

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Bonne organisation, et faites briller vos événements ! ✨
 
 ## Calendrier
 
-- [Cloud Nord](https://www.cloudnord.fr/), vendredi vers le 10 octobre à Lille (Nord).
-- [BDX I/O](https://bdxio.fr/), vendredi dans la première quinzaine de Novembre à Bordeaux.
+Le calendrier des conférences à venir est disponible sur le répo https://github.com/scraly/developers-conferences-agenda et une application est disponible avec [une vue agenda ici](https://developers.events/#/2024/calendar/-1/1731020400000).
 
 ## Accessibilité
 


### PR DESCRIPTION
Une source de vérité est bien suffisante. Ce répo est massivement utilisé et très à jour des conférences à venir. 